### PR TITLE
Response mentioned is incorrect for api.go.cd/#delete-an-agent

### DIFF
--- a/source/includes/agents/_40-delete.md.erb
+++ b/source/includes/agents/_40-delete.md.erb
@@ -33,4 +33,4 @@ You must first <a href='#update-an-agent'>disable an agent</a> before deleting i
 
 ### Returns
 
-A message confirmation if the agent was disabled.
+A message confirmation if the agent was deleted.


### PR DESCRIPTION
It says "A message confirmation if the agent was `disabled`" instead of "A message confirmation if the agent was `deleted`".