### PR TITLE
Migrate pipeline group API documentation to api.go.cd.

### DIFF
--- a/source/includes/_070-pipeline-groups.md.erb
+++ b/source/includes/_070-pipeline-groups.md.erb
@@ -1,0 +1,6 @@
+# Pipeline Groups
+
+The pipeline groups allows users to list pipeline groups along with the pipelines, stages and materials for each pipeline.
+
+<%= render_all_sub_topics('pipeline_groups') %>
+

--- a/source/includes/materials/_10-index.md
+++ b/source/includes/materials/_10-index.md
@@ -1,7 +1,7 @@
 ## Get all materials
 
 ```shell
-$ curl 'https://ci.exampe.com/go/api/config/materials' \
+$ curl 'https://ci.example.com/go/api/config/materials' \
       -u 'username:password'
 ```
 

--- a/source/includes/pipeline_groups/_00-index.md
+++ b/source/includes/pipeline_groups/_00-index.md
@@ -1,0 +1,49 @@
+## Config listing API
+
+```shell
+$ curl 'https://ci.example.com/go/api/config/pipeline_groups' \
+      -u 'username:password'
+```
+
+> The above command returns JSON structured like this:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+```
+
+```json
+[
+  {
+    "pipelines": [
+      {
+        "stages": [
+          {
+            "name": "up42_stage"
+          }
+        ],
+        "name": "up42",
+        "materials": [
+          {
+            "description": "URL: https://github.com/gocd/gocd, Branch: master",
+            "fingerprint": "2d05446cd52a998fe3afd840fc2c46b7c7e421051f0209c7f619c95bedc28b88",
+            "type": "Git"
+          }
+        ],
+        "label": "${COUNT}"
+      }
+    ],
+    "name": "first"
+  }
+]
+```
+
+This API is built primarily to support rendering of value stream mapping. As such the information rendered in the configuration is kept to a minimum.
+
+### HTTP Request
+
+`GET https://ci.example.com/go/api/config/pipeline_groups`
+
+### Returns
+
+A list of pipeline groups, pipelines in each group, stages and materials in each pipeline.

--- a/source/index.md
+++ b/source/index.md
@@ -14,6 +14,7 @@ includes:
   - 040-users
   - 050-materials
   - 060-backups
+  - 070-pipeline-groups
   - errors
 
 search: true


### PR DESCRIPTION
Fixes gocd/documentation#136