### PR TITLE
Need to call out all pre-conditions for delete-agent-api

### DIFF
--- a/source/includes/agents/_40-delete.md.erb
+++ b/source/includes/agents/_40-delete.md.erb
@@ -23,7 +23,8 @@ Content-Type: application/vnd.go.cd.v1+json; charset=utf-8
 Deletes an agent.
 
 <aside class="notice">
-You must first <a href='#update-an-agent'>disable an agent</a> before deleting it.
+You must first <a href='#update-an-agent'>disable an agent</a> and ensure that its
+<a href='#get-one-agent'>status</a> is not <code>Building</code>, before attempting to deleting it.
 </aside>
 
 


### PR DESCRIPTION
A agent in building state can be disabled, but cannot be deleted. We should call it out as well in the api doc
Currently, it just says `You must first disable an agent before deleting it.`.
