### PR TITLE
Fix the URL for User Get

### DIFF
--- a/source/includes/users/_20-show.md.erb
+++ b/source/includes/users/_20-show.md.erb
@@ -43,7 +43,7 @@ Gets a user by its login name
 
 ### HTTP Request
 
-`GET /go/api/user/:login_name`
+`GET /go/api/users/:login_name`
 
 ### Returns
 


### PR DESCRIPTION
The example actually uses the correct path, only the description points to the wrong location.