### PR TITLE
Update Agents API documents

### DIFF
--- a/source/includes/_030-agents.md.erb
+++ b/source/includes/_030-agents.md.erb
@@ -2,5 +2,8 @@
 
 The agents API allows users with administrator role to manage agents.
 
-<%= render_all_sub_topics('agents') %>
+<aside class="notice">
+  <strong>Important:</strong> Please note that this API requires using <code>v2</code> of the API using <code>Accept: application/vnd.go.cd.v2+json</code>
+</aside>
 
+<%= render_all_sub_topics('agents') %>

--- a/source/includes/agents/_10-index.md.erb
+++ b/source/includes/agents/_10-index.md.erb
@@ -3,14 +3,14 @@
 ```shell
 $ curl 'https://ci.example.com/go/api/agents' \
       -u 'username:password' \
-      -H 'Accept: application/vnd.go.cd.v1+json'
+      -H 'Accept: application/vnd.go.cd.v2+json'
 ```
 
 > The above command returns JSON structured like this:
 
 ```http
 HTTP/1.1 200 OK
-Content-Type: application/vnd.go.cd.v1+json; charset=utf-8
+Content-Type: application/vnd.go.cd.v2+json; charset=utf-8
 ```
 
 ```json

--- a/source/includes/agents/_20-show.md.erb
+++ b/source/includes/agents/_20-show.md.erb
@@ -3,14 +3,14 @@
 ```shell
 $ curl 'https://ci.example.com/go/api/agents/adb9540a-b954-4571-9d9b-2f330739d4da' \
       -u 'username:password' \
-      -H 'Accept: application/vnd.go.cd.v1+json'
+      -H 'Accept: application/vnd.go.cd.v2+json'
 ```
 
 > The above command returns JSON structured like this:
 
 ```http
 HTTP/1.1 200 OK
-Content-Type: application/vnd.go.cd.v1+json; charset=utf-8
+Content-Type: application/vnd.go.cd.v2+json; charset=utf-8
 ```
 
 ```json

--- a/source/includes/agents/_30-update.md.erb
+++ b/source/includes/agents/_30-update.md.erb
@@ -3,7 +3,7 @@
 ```shell
 $ curl 'https://ci.example.com/go/api/agents/adb9540a-b954-4571-9d9b-2f330739d4da' \
       -u 'username:password' \
-      -H 'Accept: application/vnd.go.cd.v1+json' \
+      -H 'Accept: application/vnd.go.cd.v2+json' \
       -H 'Content-Type: application/json' \
       -X PATCH \
       -d '{
@@ -15,7 +15,7 @@ $ curl 'https://ci.example.com/go/api/agents/adb9540a-b954-4571-9d9b-2f330739d4d
 
 ```http
 HTTP/1.1 200 OK
-Content-Type: application/vnd.go.cd.v1+json; charset=utf-8
+Content-Type: application/vnd.go.cd.v2+json; charset=utf-8
 ```
 
 ```json
@@ -64,6 +64,7 @@ Atleast one of the following properties must be specified, not specifying the pr
   describe_object(nil) do
     hostname  'String',            'The new hostname'
     resources ['String', 'Array'], 'A comma separated strings of resources, or an array of string resources'
+    environments ['String', 'Array'], 'A comma separated strings of environments, or an array of string environments'
     enabled   'Boolean',           'Whether an agent should be enabled. In case of agents awaiting approval, setting this will approve the agents.'
   end
  %>

--- a/source/includes/agents/_40-delete.md.erb
+++ b/source/includes/agents/_40-delete.md.erb
@@ -3,7 +3,7 @@
 ```shell
 $ curl 'https://ci.example.com/go/api/agents/adb9540a-b954-4571-9d9b-2f330739d4da' \
       -u 'username:password' \
-      -H 'Accept: application/vnd.go.cd.v1+json' \
+      -H 'Accept: application/vnd.go.cd.v2+json' \
       -X DELETE
 ```
 
@@ -11,7 +11,7 @@ $ curl 'https://ci.example.com/go/api/agents/adb9540a-b954-4571-9d9b-2f330739d4d
 
 ```http
 HTTP/1.1 200 OK
-Content-Type: application/vnd.go.cd.v1+json; charset=utf-8
+Content-Type: application/vnd.go.cd.v2+json; charset=utf-8
 ```
 
 ```json


### PR DESCRIPTION
* indicate that the version is now `v2`
* indicate that the `environments` attribute can now be updated (gocd/gocd#1522)