### PR TITLE
Making retrieval of current configuration the default documentation

### DIFF
--- a/source/includes/configuration/_02-get-historical-snapshot.md.erb
+++ b/source/includes/configuration/_02-get-historical-snapshot.md.erb
@@ -1,12 +1,18 @@
 ## Get configuration
 
 ```shell
-$ curl 'https://ci.example.com/go/api/admin/config/5059cf548db9ea2d1b9192b45529ccf0.xml' \
+$ curl 'https://ci.example.com/go/api/admin/config.xml' \
       -u 'username:password'
 ```
 
 > The above command returns the contents of the config file
 
+
+```http
+HTTP/1.1 200 OK
+X-CRUISE-CONFIG-MD5: c21b6c9f1b24a816cddf457548a987a9
+Content-Type: text/xml
+```
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <cruise
@@ -22,26 +28,23 @@ $ curl 'https://ci.example.com/go/api/admin/config/5059cf548db9ea2d1b9192b45529c
 </cruise>
 ```
 
-Gets the configuration with the specified version.
+Gets the current configuration file.
 
 <%= available_since('14.3.0') %>
 
 ### HTTP Request
 
-`GET /go/api/admin/config/:commit_sha.xml`
+`GET /go/api/admin/config/config.xml`
 
 **Other convenience APIs**
 
-`GET /go/api/admin/config/config.xml`
+`GET /go/api/admin/config/current.xml`
 
     or
 
-`GET /go/api/admin/config/current.xml`
+`GET /go/api/admin/config/:md5.xml`
 
-<aside class="notice">
-  <strong>Note:</strong> <code>config.xml</code> or <code>current.xml</code> allows retrieval of current configuration without passing in the commit sha value.
-</aside>
 
 ### Returns
 
-The contents of the configuration file with the specified revision.
+The contents of the configuration file.


### PR DESCRIPTION
And fixing confusion on md5 and commit sha
Refer https://github.com/gocd/gocd/issues/1683
