### PR TITLE
Specify from which version the API headers apply

### DIFF
--- a/source/includes/_010-introduction.md
+++ b/source/includes/_010-introduction.md
@@ -8,7 +8,7 @@ All APIs SHOULD be accessed from `https://go-server-url:8154/go/api`. All data S
 
 ## Current version
 
-By default, all requests receive **Version 1** of the API. It is recommended to explicitly request this version via the `Accept` header.
+Since v15.2.0,  all requests receive **Version 1** of the API. It is recommended to explicitly request this version via the `Accept` header.
 
 `Accept: application/vnd.go.cd.v1+json`
 


### PR DESCRIPTION
This is to clarify https://github.com/gocd/gocd/issues/1800