### PR TITLE
Change 'link' to 'url_pattern'

### DIFF
--- a/source/includes/pipeline_config/_027-tracking-tool.md.erb
+++ b/source/includes/pipeline_config/_027-tracking-tool.md.erb
@@ -3,7 +3,7 @@ json = {
   tracking_tool: {
     type: 'generic',
     attributes: {
-      link: 'https://github.com/gocd/api.go.cd/issues/${ID}',
+      url_pattern: 'https://github.com/gocd/api.go.cd/issues/${ID}',
       regex: '##(d+)'
     }
   }
@@ -20,14 +20,14 @@ end
 <%
 json = {
   attributes: {
-    link: 'https://github.com/gocd/api.go.cd/issues/${ID}',
+    url_pattern: 'https://github.com/gocd/api.go.cd/issues/${ID}',
     regex: '##(d+)'
   }
 }
 %>
 <%=
 describe_sub_object 'The generic tracking tool object', json: json, html_id: 'pipeline-config-tracking-tool-generic' do
-  link                    'String', 'In generic tracking tool, the URI to your tracking tool.'
+  url_pattern                    'String', 'In generic tracking tool, the URI to your tracking tool.'
   regex                   'String', 'In generic tracking tool, the regular expression to identify card or bug numbers from your checkin comments.'
 end
 %>


### PR DESCRIPTION
The API docs claimed that the URL should have a key called 'link' for generic tracking tools, but the code actually expects the key 'url_pattern'. The following works for Jira for instance:

      "tracking_tool": {
        "type": "generic",
        "attributes": {
          "url_pattern": "https://yourcompany.atlassian.net/issues/${ID}",
          "regex": "[A-Z]+\\-\\d+"
        }
      }
