### PR TITLE
fix example material notification hooks

### DIFF
--- a/source/includes/materials/_31-svn-notification.md.erb
+++ b/source/includes/materials/_31-svn-notification.md.erb
@@ -55,6 +55,7 @@ UUID=$(svnlook uuid $1)
 
 curl 'https://ci.example.com/go/api/material/notify/svn' \
     -u 'username:password' \
+    -H 'Confirm: true' \
     -X POST \
     -d "uuid=$UUID"
 ```

--- a/source/includes/materials/_32-git-notification.md.erb
+++ b/source/includes/materials/_32-git-notification.md.erb
@@ -50,6 +50,7 @@ The post commit hook is located at `/path/to/repository.git/hooks/post-receive`.
 
 curl 'https://ci.example.com/go/api/material/notify/git' \
     -u 'username:password' \
+    -H 'Confirm: true' \
     -X POST \
     -d "repository_url=git://git.example.com/git/funky-widgets.git"
 ```

--- a/source/includes/materials/_33-hg-notification.md.erb
+++ b/source/includes/materials/_33-hg-notification.md.erb
@@ -49,6 +49,7 @@ The hook goes into the `hgrc` file, located at `/path/to/hg/repository/.hg/hgrc`
 [hooks]
 changegroup = curl -sSL 'https://ci.example.com/go/api/material/notify/hg' \
     -u 'username:password' \
+    -H 'Confirm: true' \
     -X POST \
     -d "repository_url=ssh://hg.example.com//hg/repos/funky-widgets"
 ```


### PR DESCRIPTION
A required custom header was missing:

1241fba added the "Confirm: true" header to the example curl oneliners, but not to the hook scripts.

Without the "Confirm: true" header, "api/material/notify/svn" at least always returns a 404 error.
