### PR TITLE
Update Pipeline Config API Version

### DIFF
--- a/source/includes/_160-pipeline-config.md.erb
+++ b/source/includes/_160-pipeline-config.md.erb
@@ -3,7 +3,7 @@
 The pipeline config API allows users with administrator role to manage pipeline config.
 
 <aside class="notice">
-  <strong>Important:</strong> Please note that this API requires using <code>v3</code> of the API using <code>Accept: <%= data.apis.versions.pipeline %></code>
+  <strong>Important:</strong> Please note that this API requires using <code>v4</code> of the API using <code>Accept: <%= data.apis.versions.pipeline %></code>
 </aside>
 
 


### PR DESCRIPTION
Fixes the version mismatch in the [current docs](https://api.gocd.org/current/#pipeline-config):

     Important: Please note that this API requires using v3 of the API using Accept: application/vnd.go.cd.v4+json