### PR TITLE
Changed initial auth example from `agents` to `current_user`

### DIFF
--- a/source/includes/_020-authentication.md
+++ b/source/includes/_020-authentication.md
@@ -8,9 +8,9 @@ All APIs require you to authenticate yourself using your username and password. 
 
 ```shell
 # With shell, you can just pass the correct header with each request
-$ curl 'https://ci.example.com/go/api/agents' \
+$ curl 'https://ci.example.com/go/api/current_user' \
       -u 'username:password' \
-      -H 'Accept: application/vnd.go.cd.v2+json' \
+      -H 'Accept: application/vnd.go.cd.v1+json' \
 ```
 
 > Make sure to replace the `username` and `password` with the username and password that you use to access the go server. The above command returns the following response:
@@ -24,16 +24,25 @@ Set-Cookie: JSESSIONID=15kvus1kdrec46vk2a6jmtmo;Path=/go;Expires=Mon, 15-Jun-201
 ```json
 {
   "_links": {
-    "self": {
-      "href": "https://ci.example.com/go/api/agents"
-    },
     "doc": {
-      "href": "https://api.gocd.org/#agents"
+      "href": "https://api.gocd.org/#users"
+    },
+    "current_user": {
+      "href": "https://ci.example.com/go/api/current_user"
+    },
+    "self": {
+      "href": "https://ci.example.com/go/api/users/username"
+    },
+    "find": {
+      "href": "https://ci.example.com/go/api/users/:login_name"
     }
   },
-  "_embedded": {
-    "agents": []
-  }
+  "login_name": "username",
+  "display_name": "username",
+  "enabled": true,
+  "email": "demo@example.com",
+  "email_me": true,
+  "checkin_aliases": []
 }
 ```
 
@@ -44,7 +53,7 @@ To use Basic Authentication with the Go API, simply send the username and passwo
 Using the cookie/session returned from the previous API call, one can make further API calls. Using a cookie will dramatically improve performance of API calls especially if go is authenticating against an external source like LDAP.
 
 ```shell
-$ curl 'https://ci.example.com/go/api' \
+$ curl 'https://ci.example.com/go/api/agents' \
       -b 'JSESSIONID=15kvus1kdrec46vk2a6jmtmo' \
       -H 'Accept: application/vnd.go.cd.v1+json'
 ```


### PR DESCRIPTION
Listing all the agents can result in a larger responses than just getting the current user information for the first call, so I think it’s a better example for explaining the initial auth process.