### PR TITLE
Fix plugin infos get example

### DIFF
--- a/source/includes/plugin_info/_050-show.md.erb
+++ b/source/includes/plugin_info/_050-show.md.erb
@@ -46,7 +46,7 @@ ETag: "4167e3ec81fdac0fb29d854b36ceb981"
       "url": "https://github.com/tomzo/gocd-json-config-plugin"
     }
   },
-  "extension_info": [
+  "extensions": [
     {
       "type": "configrepo",
       "plugin_settings": {


### PR DESCRIPTION
Hi,

In the API v4 of the plugin info, the `extension_info` attribute has become `extensions` and in the documentation example there's been one miss for that replacement in the plugin info get example.

This PR is to fix that.

API code of that part: https://github.com/gocd/gocd/blob/master/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/plugin/plugin_info_representer.rb#L76

Thanks for your time,
Joseph