### PR TITLE
System-Admins V1 API DOC

### DIFF
--- a/source/includes/_200-system-admins.md.erb
+++ b/source/includes/_200-system-admins.md.erb
@@ -1,0 +1,5 @@
+# System Admins
+
+The System Admins API allows admin users to manage System Admins.
+
+<%= render_all_sub_topics('system-admins') %>

--- a/source/includes/system-admins/_00-describe.md.erb
+++ b/source/includes/system-admins/_00-describe.md.erb
@@ -1,0 +1,6 @@
+<%=
+describe_object 'The system admins object', since: '18.8.0' do
+  roles         'Array',     'The list of roles having system admin privileges.'
+  users         'Array',     'The list of users having system admin privileges.'
+end
+%>

--- a/source/includes/system-admins/_10-index.md.erb
+++ b/source/includes/system-admins/_10-index.md.erb
@@ -1,0 +1,42 @@
+## Get all system admins
+
+```shell
+$ curl 'https://ci.example.com/go/api/admin/security/system_admins' \
+      -u 'username:password' \
+      -H 'Accept: <%= data.apis.versions.roles %>'
+```
+
+> The above command returns JSON structured like this:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: <%= data.apis.versions.roles %>; charset=utf-8
+```
+
+```json
+{
+  "_links" : {
+    "doc" : {
+      "href" : "https://api.gocd.org/#system_admins"
+    },
+    "self" : {
+      "href" : "https://ci.example.com/go/api/admin/security/system_admins"
+    }
+  },
+  "roles" : [ "role1" , "role2"],
+  "users" : [ "user1" , "user2"]
+}
+```
+
+Lists all system admins which includes users and roles.
+
+<%= available_since('18.8.0') %>
+
+<p class='http-request-heading'>HTTP Request</p>
+
+`GET /go/api/admin/security/system_admins`
+
+<p class='http-request-return-description'>Returns</p>
+
+An array of [system admins](#the-system-admins-object).
+

--- a/source/includes/system-admins/_20-update.md.erb
+++ b/source/includes/system-admins/_20-update.md.erb
@@ -1,0 +1,62 @@
+## Update system admins
+
+Update system admins and replace the system admins with roles and users in the request. The role in the list of roles must be present in roles config.
+
+```shell
+$ curl 'https://ci.example.com/go/api/admin/security/system_admins' \
+      -u 'username:password' \
+      -H 'Accept: <%= data.apis.versions.roles %>' \
+      -H 'Content-Type: application/json' \
+      -H 'If-Match: "cbc5f2d5b9c13a2cc1b1efb3d8a6155d"' \
+      -X PUT \
+      -d '{
+          	"users": ["user1", "user2", "user3"],
+          	"roles": ["role1"]
+          }'
+
+```
+
+> The above command returns JSON structured like this:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: <%= data.apis.versions.roles %>; charset=utf-8
+ETag: "61406622382e51c2079c11dcbdb978fb"
+```
+
+```json
+{
+  "_links" : {
+    "doc" : {
+      "href" : "https://api.gocd.org/#system_admins"
+    },
+    "self" : {
+      "href" : "https://ci.example.com/go/api/admin/security/system_admins"
+    }
+  },
+  "roles" : [ "role1" ],
+  "users" : [ "user1" , "user2", "user3"]
+}
+```
+
+<aside class="notice">
+  <strong>Note:</strong>
+  The update system admins API requires that you submit the <code>If-Match</code>
+  header with the latest ETag value that is representative of the current
+  role.
+  <br/><br/>
+  This is required in order to avoid the "lost update" problem, where a client
+  `GET`s a resource's state, modifies it and `PUT`s it back to the server, while
+  another user has modified the state of the elastic agent config, leading to a
+  conflict.
+</aside>
+
+<%= available_since('18.8.0') %>
+
+<p class='http-request-heading'>HTTP Request</p>
+
+`PUT go/api/admin/security/system_admins`
+
+<p class='http-request-return-description'>Returns</p>
+
+An array of [system admins](#the-system-admins-object).

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -46,6 +46,7 @@ includes:
   - 188-config-repos
   - 189-artifact-store
   - 190-server-health-messages
+  - 200-system-admins
   - errors
 
 search: true


### PR DESCRIPTION
Added Documentation for System Admins Endpoint which 
Supports 'show' to list all System Admin Users and Roles.
Supports 'put' to update the System Admin Users and Roles.