### PR TITLE
No more material name when creating a config repo

### DIFF
--- a/source/includes/config_repos/_05-create.md.erb
+++ b/source/includes/config_repos/_05-create.md.erb
@@ -12,7 +12,6 @@ $   curl 'http://ci.example.com/go/api/admin/config_repos' \
       "type": "git",
       "attributes": {
         "url": "https://github.com/config-repo/gocd-json-config-example2.git",
-        "name": null,
         "branch": "master",
         "auto_update": true
       }
@@ -53,7 +52,6 @@ Content-Type: <%= data.apis.versions.config_repos %>; charset=utf-8
     "type": "git",
     "attributes": {
       "url": "https://github.com/config-repo/gocd-json-config-example2.git",
-      "name": null,
       "branch": "master",
       "auto_update": true
     }
@@ -79,3 +77,5 @@ Create a config repo object.
 <p class='http-request-return-description'>Returns</p>
 
 A new [config-repo](#the-config-repo-object) object
+
+<strong>Note:</strong> since version 18.12.0, it is not possible anymore to provide a material name as redundant with the id.


### PR DESCRIPTION
Since https://github.com/gocd/gocd/pull/5476 it is not possible to have the `name` field specified in the material when creating a new config repo.
This would lead to the following error on the frontend:
```
Received HTTP Status '500 Internal Server Error': {
      "message": "Save failed. An error occurred while saving the package config. Please check the logs for more
      information."
}
```

And the following error (snippet) in the backend:
```
2019-01-10 23:18:00,090 ERROR [qtp815992954-24] PackageDefinitionService:69 - failed to save : Attribute 'materialName' is not allowed to appear in element 'git'.
java.lang.RuntimeException: failed to save : Attribute 'materialName' is not allowed to appear in element 'git'.
    at com.thoughtworks.go.config.GoFileConfigDataSource.trySavingEntity(GoFileConfigDataSource.java:319)
    at com.thoughtworks.go.config.GoFileConfigDataSource.writeEntityWithLock(GoFileConfigDataSource.java:263)
    at com.thoughtworks.go.config.CachedGoConfig.writeEntityWithLock(CachedGoConfig.java:157)
    at com.thoughtworks.go.config.GoConfigDao.updateConfig(GoConfigDao.java:96)
    at com.thoughtworks.go.server.service.GoConfigService.updateConfig(GoConfigService.java:292)
    at com.thoughtworks.go.server.service.ConfigRepoService.update(ConfigRepoService.java:63)
    at com.thoughtworks.go.server.service.ConfigRepoService.createConfigRepo(ConfigRepoService.java:91)
    at com.thoughtworks.go.apiv1.configrepos.ConfigReposControllerV1.createRepo(ConfigReposControllerV1.java:118)
```

As it is a change that can break existing tools, it could be interesting to see that in the documentation so that other people don't loose time on this.
This is basically what that PR does.

@ketan do you think we should also remove the name from the other examples of the config repos? (I haven't tested but I'm guessing they shouldn't be available anymore either)

Thanks,
Joseph