### PR TITLE
Remove all references of the material name attribute in the config repo doc

### DIFF
--- a/source/includes/config_repos/_01-materials.md.erb
+++ b/source/includes/config_repos/_01-materials.md.erb
@@ -10,7 +10,6 @@ end
 json = {
       type: 'git',
       attributes: {
-        name: 'api-docs',
         url: 'https://github.com/gocd/api.go.cd',
         branch: 'master',
         auto_update: true
@@ -20,7 +19,6 @@ json = {
 
 <%=
 describe_sub_object 'The git material attributes', json: json, html_id: 'config-repo-git-material-attributes' do
-  name             'String',  'The name of Git material.'
   url              'String',  'The URL of the git repository.'
   branch           'String',  'The git branch to build.'
   auto_update      'Boolean', 'Whether to poll for new changes or not.'
@@ -31,7 +29,6 @@ end
 json = {
       type: 'svn',
       attributes: {
-        name: 'svn',
         url: 'svn://svn.example.com/myProject/trunk',
         username: 'admin',
         auto_update: true,
@@ -43,7 +40,6 @@ json = {
 
 <%=
 describe_sub_object 'The svn material attributes', json: json, html_id: 'config-repo-svn-material-attributes' do
-  name                'String',  'The name of Svn material.'
   url                 'String',  'The URL of the subversion repository.'
   username            'String',  'The user account for the remote repository.'
   password            'String',  'The password for the specified user.'
@@ -57,7 +53,6 @@ end
 json = {
       type: 'hg',
       attributes: {
-        name: 'api-docs',
         url: 'http://username:password@hg.example.com/hg/api.go.cd',
         auto_update: true
       }
@@ -65,7 +60,6 @@ json = {
 %>
 <%=
 describe_sub_object 'The mercurial material attributes', json: json, html_id: 'config-repo-hg-material-attributes' do
-  name           'String',  'The name of hg material.'
   url            'String',  'The URL of the mercurial repository.'
   auto_update    'Boolean', 'Whether to poll for new changes or not.'
 end
@@ -75,7 +69,6 @@ end
 json = {
   type: 'p4',
   attributes: {
-    name: 'api-docs',
     port: 'p4.example.com:8080',
     use_tickets: true,
     view: 'sample_view',
@@ -88,7 +81,6 @@ json = {
 
 <%=
 describe_sub_object 'The perforce material attributes', json: json, html_id: 'config-repo-p4-material-attributes' do
-  name                'String',  'The name of p4 material.'
   port                'String',  'Perforce server connection to use (`[transport:]host:port`).'
   use_tickets         'Boolean', 'Whether to work with the Perforce tickets or not.'
   view                'String',  'The Perforce view.'
@@ -103,7 +95,6 @@ end
 json = {
   type: 'tfs',
   attributes: {
-    name: 'tfs',
     url: 'http://tfs.exampe.com:8000/tfs',
     project_path: '$/',
     domain: 'corporate/domain',
@@ -115,7 +106,6 @@ json = {
 
 <%=
 describe_sub_object 'The tfs material attributes', json: json, html_id: 'config-repo-tfs-material-attributes' do
-  name                'String',  'The name of this material.'
   url                 'String',  'The URL for the Collection on the TFS Server.'
   project_path        'String',  'The project path within the TFS collection.'
   domain              'String',  'The domain name for TFS authentication credentials.'

--- a/source/includes/config_repos/_03-index.md.erb
+++ b/source/includes/config_repos/_03-index.md.erb
@@ -40,7 +40,6 @@ Content-Type: application/json; charset=utf-8
           "type": "git",
           "attributes": {
             "url": "https://github.com/config-repo/gocd-json-config-example.git",
-            "name": null,
             "branch": "master",
             "auto_update": true
           }

--- a/source/includes/config_repos/_04-show.md.erb
+++ b/source/includes/config_repos/_04-show.md.erb
@@ -35,7 +35,6 @@ ETag: "05548388f7ef5042cd39f7fe42e85735"
     "type": "git",
     "attributes": {
       "url": "https://github.com/config-repo/gocd-json-config-example.git",
-      "name": null,
       "branch": "master",
       "auto_update": true
     }

--- a/source/includes/config_repos/_06-edit.md.erb
+++ b/source/includes/config_repos/_06-edit.md.erb
@@ -14,7 +14,6 @@ $ curl 'https://ci.example.com/go/api/admin/config_repos/repo-1' \
               "type": "git",
               "attributes": {
                 "url": "https://github.com/config-repo/gocd-json-config-example2.git",
-                "name": null,
                 "branch": "master",
                 "auto_update": true
               }
@@ -55,7 +54,6 @@ ETag: "e89135b38ddbcd9380c83eb524647bdd"
     "type": "git",
     "attributes": {
       "url": "https://github.com/config-repo/gocd-json-config-example2.git",
-      "name": null,
       "branch": "master",
       "auto_update": true
     }


### PR DESCRIPTION
That's the rest of the change started in https://github.com/gocd/api.go.cd/pull/268

@ketan do you see anything else?
I'm not sure how this one plays out: https://github.com/gocd/api.go.cd/blob/master/build_gocd_pipelines/18.12.0.gopipeline.json#L15

Thanks!
Joseph