### PR TITLE
Modified backup API documentation to reflect v2 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Checkout the live documentation at https://api.gocd.org
 $ bundle install --path .bundle --binstubs
 ```
 
-### Serve the documentation locally
+### Run the API documentation locally on http://localhost:4567
 
 ```
-$ ./bin/middleman server
+$ bundle exec ./bin/middleman server
 ```
 
 ### Generating the static website

--- a/data/apis/versions.yml
+++ b/data/apis/versions.yml
@@ -1,5 +1,5 @@
 agent: 'application/vnd.go.cd.v4+json'
-backup: 'application/vnd.go.cd.v1+json'
+backup: 'application/vnd.go.cd.v2+json'
 dashboard: 'application/vnd.go.cd.v3+json'
 elastic_profiles: 'application/vnd.go.cd.v1+json'
 environments: 'application/vnd.go.cd.v2+json'

--- a/source/includes/backups/_00-describe.md.erb
+++ b/source/includes/backups/_00-describe.md.erb
@@ -1,7 +1,10 @@
 <%=
-describe_object 'The backup object', since: '15.2.0' do
+describe_object 'The backup object', since: '19.3.0' do
   time              'DateTime',   'The time of the backup'
-  path              'String',     'The filesystem location of the backup'
+  path              'String',     'The filesystem location where the backed up files are stored'
   user              'Object',     'The user that performed this backup'
+  status            'String',     'Status of the backup. Possible values are COMPLETED, IN_PROGRESS, ERROR, ABORTED'
+  progress_status   'String',     'If the status of the backup is IN_PROGRESS, then this field gives more granular details about the back up in progress. Possible values are STARTING, CREATING_DIR, BACKUP_VERSION_FILE, BACKUP_CONFIG, BACKUP_CONFIG_REPO, BACKUP_DATABASE, POST_BACKUP_SCRIPT_START, POST_BACKUP_SCRIPT_COMPLETE'
+  message           'String',     'The detailed message corresponding to the \'status\' or \'progress_status\' fields'
 end
 %>

--- a/source/includes/backups/_00-describe.md.erb
+++ b/source/includes/backups/_00-describe.md.erb
@@ -1,5 +1,5 @@
 <%=
-describe_object 'The backup object', since: '19.3.0' do
+describe_object 'The Backup Object', since: '19.3.0' do
   time              'DateTime',   'The time of the backup'
   path              'String',     'The filesystem location where the backed up files are stored'
   user              'Object',     'The user that performed this backup'

--- a/source/includes/backups/_10-create.md.erb
+++ b/source/includes/backups/_10-create.md.erb
@@ -1,19 +1,34 @@
-## Create a backup
+## Schedules backup asynchronously.
 
 ```shell
 $ curl 'https://ci.example.com/go/api/backups' \
+      -i \
       -u 'username:password' \
-      -H 'Confirm: true' \
+      -H 'X-GoCD-Confirm: true' \
       -H 'Accept: <%= data.apis.versions.backup %>' \
       -X POST
 ```
 
-> The above command returns JSON structured like this:
+> The above command returns an empty response body with a response code of 202 (Accepted) to indicate that 
+request to backup is accepted and is scheduled asynchronously. It returns location header in the response 
+that can be used for polling the status of the backup.
 
-```http
-HTTP/1.1 200 OK
-Content-Type: <%= data.apis.versions.backup %>; charset=utf-8
+```http 
+HTTP/1.1 202 Accepted
+Content-Type: application/vnd.go.cd.v2+json;charset=utf-8
+Location: /go/api/backups/:scheduled_backup_id
+Retry-After: 5
 ```
+
+```shell
+$ curl 'https://ci.example.com/go/api/backups/:scheduled_backup_id' \
+      -i \
+      -u 'username:password' \
+      -H 'Accept: <%= data.apis.versions.backup %>' \
+      -X GET
+```
+
+> The above command is used to poll the status of the backup that was scheduled previously. It returns JSON structured like this:
 
 ```json
 {
@@ -24,6 +39,9 @@ Content-Type: <%= data.apis.versions.backup %>; charset=utf-8
   },
   "time": "2015-08-07T10:07:19.868Z",
   "path": "/var/lib/go-server/serverBackups/backup_20150807-153719",
+  "status" : "COMPLETED",
+  "progress_status" : "BACKUP_DATABASE",
+  "message" : "Backup was generated successfully.",
   "user": {
     "_links": {
       "doc": {
@@ -34,6 +52,9 @@ Content-Type: <%= data.apis.versions.backup %>; charset=utf-8
       },
       "find": {
         "href": "https://ci.example.com/go/api/users/:login_name"
+      },
+      "current_user" : {
+        "href" : "https://ci.example.com/go/api/users/current_user"
       }
     },
     "login_name": "username"
@@ -41,32 +62,31 @@ Content-Type: <%= data.apis.versions.backup %>; charset=utf-8
 }
 ```
 
-Create a server backup.
-
 <aside class="warning">
   The server may be unavailable during the time that the backup is being taken.
 </aside>
 
-<aside class="notice">
-  The response from the call will not be received till the backup is complete
-  (synchronous). If the data to be backed up is a lot, this can take minutes
-  to complete.
-</aside>
-
-
-<%=
-available_since('15.2.0') do
+<%= available_since('19.3.0') do
   in_version '15.1.0', url: 'https://www.gocd.org/documentation/user/15.1.0/api/backup_api.html'
   in_version '14.4.0', url: 'https://www.gocd.org/documentation/user/14.4.0/api/backup_api.html'
   in_version '14.3.0', url: 'https://www.gocd.org/documentation/user/14.3.0/api/backup_api.html'
 end
 %>
 
-
 <p class='http-request-heading'>HTTP Request</p>
 
 `POST /go/api/backups`
 
-<p class='http-request-return-description'>Returns</p>
+<p class='http-request-return-description'>
+  Returns an empty response body with a response code 202 (Accepted) and location header containing the link to be polled for checking the status of the backup.
+</p>
 
+`GET /go/api/backups/:scheduled_backup_id`
+
+<aside class="notice">
+  <strong>Note:</strong>
+  You can use keyword 'running' as a scheduled_backup_id to know the details of a running backup.
+</aside>
+
+<p class='http-request-return-description'>Returns</p>
 A new [backup object](#the-backup-object).

--- a/source/includes/backups/_20-get.md.erb
+++ b/source/includes/backups/_20-get.md.erb
@@ -46,9 +46,7 @@ $ curl 'https://ci.example.com/go/api/backups/:backup_id' \
   The server may be unavailable during the time that the backup is being taken.
 </aside>
 
-<%= available_since('19.3.0') do
-end
-%>
+<%= available_since('19.3.0')%>
 
 `GET /go/api/backups/:backup_id`
 

--- a/source/includes/backups/_20-get.md.erb
+++ b/source/includes/backups/_20-get.md.erb
@@ -1,24 +1,4 @@
-## Schedule Backup
-
-```shell
-$ curl 'https://ci.example.com/go/api/backups' \
-      -i \
-      -u 'username:password' \
-      -H 'X-GoCD-Confirm: true' \
-      -H 'Accept: <%= data.apis.versions.backup %>' \
-      -X POST
-```
-
-> The above command returns an empty response body with a response code of 202 (Accepted) to indicate that 
-request to backup is accepted and is scheduled asynchronously. It returns location header in the response 
-that can be used for polling the status of the backup.
-
-```http 
-HTTP/1.1 202 Accepted
-Content-Type: application/vnd.go.cd.v2+json;charset=utf-8
-Location: /go/api/backups/:backup_id
-Retry-After: 5
-```
+## Get Backup
 
 ```shell
 $ curl 'https://ci.example.com/go/api/backups/:backup_id' \
@@ -74,10 +54,12 @@ $ curl 'https://ci.example.com/go/api/backups/:backup_id' \
 end
 %>
 
-<p class='http-request-heading'>HTTP Request</p>
+`GET /go/api/backups/:backup_id`
 
-`POST /go/api/backups`
+<aside class="notice">
+  <strong>Note:</strong>
+  You can use keyword 'running' as a backup_id to know the details of a running backup.
+</aside>
 
-<p class='http-request-return-description'>
-  Returns an empty response body with a response code 202 (Accepted) and location header containing the link to be polled for checking the status of the backup.
-</p>
+<p class='http-request-return-description'>Returns</p>
+A new [backup object](#the-backup-object).

--- a/source/includes/backups/_20-get.md.erb
+++ b/source/includes/backups/_20-get.md.erb
@@ -47,10 +47,6 @@ $ curl 'https://ci.example.com/go/api/backups/:backup_id' \
 </aside>
 
 <%= available_since('19.3.0') do
-  in_version '15.2.0', url: 'https://api.gocd.org/15.2.0/#backups'
-  in_version '15.1.0', url: 'https://www.gocd.org/documentation/user/15.1.0/api/backup_api.html'
-  in_version '14.4.0', url: 'https://www.gocd.org/documentation/user/14.4.0/api/backup_api.html'
-  in_version '14.3.0', url: 'https://www.gocd.org/documentation/user/14.3.0/api/backup_api.html'
 end
 %>
 


### PR DESCRIPTION
In this check-in, modified backup API documentation per [#5781](#5781)

- [x] README file was missing some instructions to get API docs running locally. Added those details.

- [x] Modified ServerBackup object details to reflect the recent v2 changes

- [x] Modified API doc to reflect request, response payload, header details as per v2 changes
