### PR TITLE
Fix 359 add authentication documentation

### DIFF
--- a/source/includes/server_health_messages/_10-show.md.erb
+++ b/source/includes/server_health_messages/_10-show.md.erb
@@ -2,6 +2,7 @@
 
 ```shell
 $ curl 'https://ci.example.com/go/api/server_health_messages' \
+    -u 'username:password' \
     -H 'Accept: <%= data.apis.versions.server_health %>'
 ```
 


### PR DESCRIPTION
Add the `-u 'username:password'` part to the example.