### PR TITLE
Fix 360 improve documentation for plugin settings

### DIFF
--- a/source/includes/plugin_settings/_02-show.md.erb
+++ b/source/includes/plugin_settings/_02-show.md.erb
@@ -51,11 +51,12 @@ ETag: "05548388f7ef5042cd39f7fe42e85735"
 }
 ```
 
-Gets the stored plugin settings for the specified plugin id.
+Gets the stored plugin settings for the specified plugin id. Be aware that a settings object is created on demand and may not be availble!
 
 <aside class="notice">
   <strong>Note:</strong> Please remember to save the value of the `ETag` header for conditional posts, see the <a href='#update-plugin-settings'>update plugin settings</a> documentation for more details.
 </aside>
+
 
 <%= available_since('17.9.0') %>
 
@@ -65,4 +66,4 @@ Gets the stored plugin settings for the specified plugin id.
 
 <p class='http-request-return-description'>Returns</p>
 
-A [Plugin Settings](#the-plugin-settings-object) object
+A [Plugin Settings](#the-plugin-settings-object) object or an error 404 if the plugin was not yet configured.

--- a/source/includes/plugin_settings/_02-show.md.erb
+++ b/source/includes/plugin_settings/_02-show.md.erb
@@ -51,7 +51,7 @@ ETag: "05548388f7ef5042cd39f7fe42e85735"
 }
 ```
 
-Gets the stored plugin settings for the specified plugin id. Be aware that a settings object is created on demand and may not be availble!
+Gets the stored plugin settings for the specified plugin id, if the plugin is configured.
 
 <aside class="notice">
   <strong>Note:</strong> Please remember to save the value of the `ETag` header for conditional posts, see the <a href='#update-plugin-settings'>update plugin settings</a> documentation for more details.

--- a/source/includes/plugin_settings/_03-create.md.erb
+++ b/source/includes/plugin_settings/_03-create.md.erb
@@ -72,7 +72,10 @@ Content-Type: <%= data.apis.versions.plugin_settings %>; charset=utf-8
 
 ```
 
-Create plugin settings for a plugin based on user inputs.
+Create plugin settings for a plugin based on user inputs. The keys are
+dependent on the plugin to be configured. Use the result of
+[Get plugin info](#get-plugin-info) to find the possible keys under
+`extensions`/`plugin_settings`/`configurations`.
 
 
 <%= available_since('17.9.0') %>


### PR DESCRIPTION
Inform API users about the, maybe unexpected, behaviour on
  get plugin settings.
Add link to the source of information how to get the valid
  fields for creating a plugin setting.