### PR TITLE
Fix layout issues

### DIFF
--- a/source/javascripts/app/_gdpr-banner.js
+++ b/source/javascripts/app/_gdpr-banner.js
@@ -14,12 +14,14 @@
           ])
         ]);
 
+      var pageWrapperElement = document.querySelector(".page-wrapper");
+
       function hide() {
         setCookie();
-        document.body.removeChild(banner);
+        pageWrapperElement.removeChild(banner);
       }
 
-      document.body.insertBefore(banner, document.body.firstChild);
+      pageWrapperElement.insertBefore(banner, pageWrapperElement.firstChild);
     }
   }
 

--- a/source/stylesheets/_gdpr.scss
+++ b/source/stylesheets/_gdpr.scss
@@ -3,7 +3,8 @@
   background: #fff;
   padding: 10px 66px;
   width: 100%;
-  position: fixed;
+  position: sticky;
+  top: 0;
   z-index: 100;
 
   box-shadow: 0 3px 5px 0 rgba(0,0,0,.1);

--- a/source/stylesheets/_gocd-overrides.scss
+++ b/source/stylesheets/_gocd-overrides.scss
@@ -2,6 +2,10 @@
   padding-top: 0;
 }
 
+blockquote + div.highlight > pre.highlight, div.highlight + div.highlight > pre.highlight {
+  padding-top: 0;
+}
+
 .highlight + blockquote {
   padding-top: 0;
 }
@@ -12,6 +16,15 @@ blockquote + .highlight {
 
 .tocify-wrapper > img {
     margin: 10px;
+}
+
+div.highlight {
+  float: right;
+  width: 50%;
+}
+
+pre.highlight {
+  width: 100%;
 }
 
 


### PR DESCRIPTION
There is now a div.highlight which is a wrapper of the pre.highlight, which caused layouts to break (subtly), between 19.5.0 and 19.6.0. Presumably because of an upgrade of `middleman-syntax` or `redcarpet` (the Markdown pre-processor). Maybe.

Was working in 19.5.0: (https://api.gocd.org/19.5.0/#get-stage-instance)

<img width="1209" alt="2019_09_03_16-33-46" src="https://user-images.githubusercontent.com/172235/64207598-f132bc00-ce6a-11e9-9334-c46420d1d9a3.png">

Is broken currently: (https://api.gocd.org/current/#get-stage-instance):

<img width="1208" alt="2019_09_03_16-33-12" src="https://user-images.githubusercontent.com/172235/64207920-a9606480-ce6b-11e9-8756-5ccf1dece4d0.png">

Is fixed after this PR:

<img width="1210" alt="2019_09_03_16-33-38" src="https://user-images.githubusercontent.com/172235/64207936-b2513600-ce6b-11e9-8c8e-406b5d94ff7f.png">

I prefer the older colors. The `rouge` gem was also updated.