### PR TITLE
Make GDPR banner work with IE11 as well

### DIFF
--- a/source/javascripts/app/_gdpr-banner.js
+++ b/source/javascripts/app/_gdpr-banner.js
@@ -6,11 +6,11 @@
       setCookie();
 
       var banner = el("div", {class: "gdpr-banner"}, [
-        on(el("i", {class: "gdpr-close"}), "click", hide),
         el("p", {}, [
           "Our site uses ", link("cookies", "https://www.thoughtworks.com/privacy-policy#cookie-section"),
           " for analytics. If you're unsure about it, take a look at our ",
-          link("privacy policy", "https://www.thoughtworks.com/privacy-policy"), "."
+          link("privacy policy", "https://www.thoughtworks.com/privacy-policy"), ".",
+          on(el("i", {class: "gdpr-close"}), "click", hide),
           ])
         ]);
 

--- a/source/javascripts/app/_gdpr-banner.js
+++ b/source/javascripts/app/_gdpr-banner.js
@@ -22,6 +22,9 @@
       }
 
       pageWrapperElement.insertBefore(banner, pageWrapperElement.firstChild);
+      setTimeout(function() {
+        window.scrollBy(0, -36);
+      }, 500);
     }
   }
 

--- a/source/stylesheets/_gdpr.scss
+++ b/source/stylesheets/_gdpr.scss
@@ -9,9 +9,16 @@
 
   box-shadow: 0 3px 5px 0 rgba(0,0,0,.1);
 
-  text-align: center;
   font-family: "Helvetica Neue", Helvetica, Arial, "Microsoft Yahei","微软雅黑", STXihei, "华文细黑", sans-serif;
   font-size: 14px;
+
+  @media (min-width: $tablet-width + $nav-width) {
+    text-align: center;
+  }
+  @media (max-width: $tablet-width + $nav-width) {
+    text-align: left;
+  }
+
 
   p { margin: 0; padding: 0; }
 
@@ -31,9 +38,9 @@
     position: absolute;
     width: 16px;
     height: 16px;
-    top: 50%;
-    right: 40px;
+    bottom: 10px;
     margin-top: -8px;
+    margin-left: 10px;
     cursor: pointer;
 
     &:before, &:after {

--- a/source/stylesheets/_gdpr.scss
+++ b/source/stylesheets/_gdpr.scss
@@ -49,3 +49,7 @@
     &:after { transform: rotate(-45deg); }
   }
 }
+
+.gdpr-banner ~ * {
+  transform: translateY(36px);
+}

--- a/source/stylesheets/_gdpr.scss
+++ b/source/stylesheets/_gdpr.scss
@@ -3,7 +3,7 @@
   background: #fff;
   padding: 10px 66px;
   width: 100%;
-  position: sticky;
+  position: fixed;
   top: 0;
   z-index: 100;
 
@@ -48,8 +48,4 @@
     &:before { transform: rotate(45deg); }
     &:after { transform: rotate(-45deg); }
   }
-}
-
-.gdpr-banner ~ * {
-  transform: translateY(36px);
 }


### PR DESCRIPTION
* Switch to using "position: fixed".
* ~~Remove the translate which was making the horizontal scroll appear.~~

Since the banner was moved inside the page-wrapper, the translate was not really doing anything useful. It was initially added to shift the page down 36px so that the banner does not cover the content. However, when moved inside the page-wrapper, it does cover the content. ~~So, translate is not necessary~~. [Edit: Brought back translate since it can be useful, to help not cover content even in this case]

In this case, "position: fixed" works as well as "position: sticky" anyway. So, using the more standard one.

CC: @marques-work