### PR TITLE
Fix typo, git -> svn on 19.6

### DIFF
--- a/source/includes/materials/_31-svn-notification.md.erb
+++ b/source/includes/materials/_31-svn-notification.md.erb
@@ -33,7 +33,7 @@ The following json payload must be specified.
 
 <%=
   describe_object(nil) do
-    repository_url  'String', 'The git repository url as defined in `cruise-config.xml` or a Config Repo'
+    repository_url  'String', 'The svn repository url as defined in `cruise-config.xml` or a Config Repo'
   end
  %>
 


### PR DESCRIPTION
Typo fix on 19.6