### PR TITLE
Fix typo - git -> svn

### DIFF
--- a/source/includes/materials/_31-svn-notification.md.erb
+++ b/source/includes/materials/_31-svn-notification.md.erb
@@ -33,7 +33,7 @@ The following json payload must be specified.
 
 <%=
   describe_object(nil) do
-    repository_url  'String', 'The git repository url as defined in `cruise-config.xml` or a Config Repo'
+    repository_url  'String', 'The svn repository url as defined in `cruise-config.xml` or a Config Repo'
   end
  %>
 


### PR DESCRIPTION
We may also need to document v2 of the Materials API, or add the `uuid` parameter in v1, depending on what we decide. But for now, I'm just fixing the typo.