### PR TITLE
Fix wrong maintenance mode URL

### DIFF
--- a/source/includes/maintenance-mode/_70-info.md.erb
+++ b/source/includes/maintenance-mode/_70-info.md.erb
@@ -1,7 +1,7 @@
 ## Get Maintenance Mode Info
 
 ```shell
-$ curl 'https://ci.example.com/go/api/maintenance_mode/info' \
+$ curl 'https://ci.example.com/go/api/admin/maintenance_mode/info' \
 -u 'username:password' \
 -H 'Accept: <%= data.apis.versions.maintenance_mode %>'
 ```


### PR DESCRIPTION
Should be `/go/api/admin/maintenance_mode`.