### PR TITLE
Fix notification endpoint payload

### DIFF
--- a/source/includes/materials-notify/_31-svn-notification.md.erb
+++ b/source/includes/materials-notify/_31-svn-notification.md.erb
@@ -5,7 +5,7 @@ $ curl 'https://ci.example.com/go/api/admin/materials/svn/notify' \
       -u 'username:password' \
       -H 'Accept: <%= data.apis.versions.materials %>' \
       -X POST \
-      -d {"repository_url": "http://svn.example.com/test-repo"}
+      -d '{"repository_url": "http://svn.example.com/test-repo"}'
 ```
 
 > The above command returns the following response:
@@ -56,7 +56,7 @@ curl 'https://ci.example.com/go/api/admin/materials/svn/notify' \
     -H 'Accept: <%= data.apis.versions.materials %>' \
     -H 'Content-Type: application/json'
     -X POST \
-    -d {"repository_url": "http://svn.example.com/test-repo"}
+    -d '{"repository_url": "http://svn.example.com/test-repo"}'
 
 # -- or using UUID --
 
@@ -64,9 +64,9 @@ REPOS="$1"
 REV="$2"
 UUID=$(svnlook uuid $1)
 
-curl 'https://ci.example.com/go/api/material/notify/svn' \
+curl 'https://ci.example.com/go/api/material/svn/notify' \
     -u 'username:password' \
     -H 'Confirm: true' \
     -X POST \
-    -d {"uuid": "$UUID"}
+    -d '{"uuid": "$UUID"}'
 ```

--- a/source/includes/materials-notify/_32-git-notification.md.erb
+++ b/source/includes/materials-notify/_32-git-notification.md.erb
@@ -6,7 +6,7 @@ $ curl 'https://ci.example.com/go/api/admin/materials/git/notify' \
       -H 'Accept: <%= data.apis.versions.materials %>' \
       -H 'Content-Type: application/json' \
       -X POST \
-      -d {"repository_url": "git://git.example.com/git/funky-widgets.git"}
+      -d '{"repository_url": "git://git.example.com/git/funky-widgets.git"}'
 ```
 
 > The above command returns the following response:
@@ -50,10 +50,10 @@ The post commit hook is located at `/path/to/repository.git/hooks/post-receive`.
 ```bash
 #!/bin/sh
 
-curl 'https://ci.example.com/go/api/admin/materials/notify/git' \
+curl 'https://ci.example.com/go/api/admin/materials/git/notify' \
     -u 'username:password' \
     -H 'Accept: <%= data.apis.versions.materials %>' \
     -H 'Content-Type: application/json' \
     -X POST \
-    -d "repository_url=git://git.example.com/git/funky-widgets.git"
+    -d '{"repository_url": "git://git.example.com/git/funky-widgets.git"}'
 ```

--- a/source/includes/materials-notify/_33-hg-notification.md.erb
+++ b/source/includes/materials-notify/_33-hg-notification.md.erb
@@ -6,7 +6,7 @@ $ curl 'https://ci.example.com/go/api/admin/materials/hg/notify' \
       -H 'Accept: <% data.apis.versions.materials %>' \
       -H 'Content-Type: application/json %>' \
       -X POST \
-      -d {"repository_url": "ssh://hg.example.com/hg/repos/funky-widgets"}
+      -d '{"repository_url": "ssh://hg.example.com/hg/repos/funky-widgets"}'
 ```
 
 > The above command returns the following response:
@@ -54,5 +54,5 @@ changegroup = curl -sSL 'https://ci.example.com/go/api/admin/materials/hg/notify
     -H 'Accept: <%= data.apis.versions.materials %>' \
     -H 'Content-Type: application/json' \
     -X POST \
-    -d {"repository_url": "ssh://hg.example.com/hg/repos/funky-widgets"}
+    -d '{"repository_url": "ssh://hg.example.com/hg/repos/funky-widgets"}'
 ```

--- a/source/includes/materials-notify/_34-other-scm-notification.md.erb
+++ b/source/includes/materials-notify/_34-other-scm-notification.md.erb
@@ -6,7 +6,7 @@ $ curl 'https://ci.example.com/go/api/admin/materials/scm/notify' \
       -H 'Accept: <%= data.apis.versions.materials %>' \
       -H 'Content-Type: application/json' \
       -X POST \
-      -d {"scm_name": "material_name"}
+      -d '{"scm_name": "material_name"}'
 ```
 
 > The above command returns the following response:


### PR DESCRIPTION
curl sends invalid JSON if the request body isn't quoted and answers with:

```json
{
  "error": "Payload data is not valid JSON: com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Unterminated object at line 1 column 31 path $.repository_url"
}
```