### PR TITLE
Add initial changelog for GoCD 21.4.0

### DIFF
--- a/source/includes/changelog/_20-09-0.md.erb
+++ b/source/includes/changelog/_20-09-0.md.erb
@@ -12,7 +12,7 @@
 - Introduced version 3 of the [Secret Config API](#secret-configs).
   - This version adds support for `cluster_profile` as entity type for rules.
 - Stages endpoints have been regrouped and split between [Stages](#stages) and [Stage Instances](#stage-instances). Also, introduced version 3 of the Stage Instances API.
-  - Version 3 of the Stage Instances API updates the [Get Stage Instance](#get-stage-instance) API to return additional atrributes `scheduled_at` and `last_transitioned_time`.
+  - Version 3 of the Stage Instances API updates the [Get Stage Instance](#get-stage-instance) API to return additional attributes `scheduled_at` and `last_transitioned_time`.
 
 ### Removed
 
@@ -26,3 +26,4 @@
 - <%= deprecated_api_message({api_name: 'Config Repo', deprecated_in_release: '20.8.0', old_api_version: 3, new_api_version: 4, api_section: 'config-repo', removal_in_release: '20.11.0'}) %>
 - <%= deprecated_api_message({api_name: 'Pluggable SCM', deprecated_in_release: '20.9.0', old_api_version: 3, new_api_version: 4, api_section: 'pluggable-scms', removal_in_release: '21.1.0'}) %>
 - <%= deprecated_api_message({api_name: 'Secret Config', deprecated_in_release: '20.9.0', old_api_version: 2, new_api_version: 3, api_section: 'secret-configs', removal_in_release: '21.1.0'}) %>
+- <%= deprecated_api_message({api_name: 'Stage Instances', deprecated_in_release: '20.9.0', old_api_version: 2, new_api_version: 3, api_section: 'stage-instances', removal_in_release: '21.1.0'}) %>

--- a/source/includes/changelog/_21-4-0.md.erb
+++ b/source/includes/changelog/_21-4-0.md.erb
@@ -1,0 +1,13 @@
+## Changes in 21.4.0
+
+### Added
+
+- No addition in this release
+
+### Removed
+
+- <%= removed_api_message({api_name: 'Stage Instances', old_api_version: 2, new_api_version: 3, api_section: 'stage-instances'}) %>
+
+### Deprecations
+
+- No deprecations in this release


### PR DESCRIPTION
Also retconned the documentation for deprecation of Stage Instances v2 into the earlier 20.9.0 changelog, which was missed. Since the API itself has been returning the deprecation info since 20.9.0, fields have only been added, and it has been a year since release this should be OK. See https://github.com/gocd/gocd/pull/9987