### PR TITLE
Use correct API name

### DIFF
--- a/source/includes/package-config/_06-delete.md.erb
+++ b/source/includes/package-config/_06-delete.md.erb
@@ -29,7 +29,7 @@ Deletes a package from the respective repository if it is not associated with an
 
 <p class='http-request-heading'>HTTP Request</p>
 
-`DELETE /go/api/admin/package/:package_id`
+`DELETE /go/api/admin/packages/:package_id`
 
 <p class='http-request-return-description'>Returns</p>
 

--- a/source/includes/package-config/_07-usages.md.erb
+++ b/source/includes/package-config/_07-usages.md.erb
@@ -42,7 +42,7 @@ Gets the list of pipelines and group which uses the said package as a material
 
 <p class='http-request-heading'>HTTP Request</p>
 
-`GET /go/api/admin/package/:package_id/usages`
+`GET /go/api/admin/packages/:package_id/usages`
 
 <p class='http-request-return-description'>Returns</p>
 


### PR DESCRIPTION
This replaces the missing 's' on the API name in the docs. 