### PR TITLE
Use supported version of Dashboard API

### DIFF
--- a/data/apis/versions.yml
+++ b/data/apis/versions.yml
@@ -1,7 +1,7 @@
 latest: 'application/vnd.go.cd+json'
 agent: 'application/vnd.go.cd.v7+json'
 backup: 'application/vnd.go.cd.v2+json'
-dashboard: 'application/vnd.go.cd.v3+json'
+dashboard: 'application/vnd.go.cd.v4+json'
 cluster_profiles: 'application/vnd.go.cd.v1+json'
 elastic_profiles: 'application/vnd.go.cd.v2+json'
 environments: 'application/vnd.go.cd.v3+json'


### PR DESCRIPTION
Version 3 was removed in GoCD v23.2.0 https://api.gocd.org/23.2.0/\#changes-in-23-2-0