### PR TITLE
Fixing typo

### DIFF
--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -13,7 +13,7 @@ Error Code | Meaning
 409        | Conflict              -- The request could not be completed due to a conflict with the current state of the resource.
 410        | Gone                  -- The resource requested has been removed from our servers.
 412        | Precondition Failed   -- The request could not be completed because the state of the resource is not the latest while being updated.
-422        | Unprocessible Entity  -- The server understood the request, but the request is semantically erroneous.
+422        | Unprocessable Entity  -- The server understood the request, but the request is semantically erroneous.
 500        | Internal Server Error -- We had a problem with our server. Try again later.
 501        | Not implemented       -- The server does not support the functionality required to fulfill the request.
 503        | Service Unavailable   -- We're temporarially offline for maintanance. Please try again later.


### PR DESCRIPTION
Fixing typo "Unprocessible" => "Unprocessable"